### PR TITLE
Dynamic timer start/stop functionality

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,6 +6,9 @@ module.exports = {
 		'plugin:svelte/recommended',
 		'prettier'
 	],
+	globals: {
+		NodeJS: true
+	},
 	parser: '@typescript-eslint/parser',
 	plugins: ['@typescript-eslint'],
 	parserOptions: {

--- a/src/lib/components/Timer/Timer.svelte
+++ b/src/lib/components/Timer/Timer.svelte
@@ -1,42 +1,104 @@
 <script lang="ts">
 	import {
 		watchTimerStatus,
-		setTimerStatus,
 		timerPausedStore,
-		timerIntervalMinutesStore
+		timerIntervalMinutesStore,
+		timerPausedEpochStore,
+		watchRoundInProgress,
+		watchPausedTimestamp,
+		watchStartEpoch,
+		setStartEpoch,
+		timerStartEpochStore,
+		setPausedTimestamp,
+		setTimerStatus,
+		roundInProgressStore,
+		setRoundInProgress
 	} from '$lib/firebase';
-	import { tweened } from 'svelte/motion';
+	import { onDestroy, onMount } from 'svelte';
 
-	let percentage: number;
-	let elapsed = 0;
-	let duration = $timerIntervalMinutesStore * 60;
-	let timer = tweened(duration);
+	let timerInterval: NodeJS.Timeout;
+	let time: string;
+	let timePercentage: number;
 
-	setInterval(() => {
-		if ($timer > 0 && $timerPausedStore) {
-			$timer--;
-			elapsed++;
-		} else if ($timer === 0) {
-			setTimerStatus(false);
+	function getRemainingTimeNewlyJoined() {
+		if (!$roundInProgressStore)
+			return `${$timerIntervalMinutesStore < 10 ? '0' : ''}${$timerIntervalMinutesStore}:00`;
+		if ($timerPausedStore) {
+			const timeRemainingBeforePause =
+				$timerIntervalMinutesStore * 60 - ($timerPausedEpochStore - $timerStartEpochStore);
+			return formatRemainingTime(timeRemainingBeforePause);
+		} else {
+			return getRemainingTime();
 		}
-	}, 1000);
+	}
 
-	$: percentage = 100 - (elapsed / duration) * 100;
-	$: minutes = Math.floor($timer / 60);
-	$: seconds = Math.floor($timer - minutes * 60);
-	$: displayMinutes = minutes < 10 ? `0${minutes}` : minutes;
-	$: displaySeconds = seconds < 10 ? `0${seconds}` : seconds;
+	function getRemainingTime() {
+		if ($roundInProgressStore && $timerPausedStore === false) {
+			const currentTime = Math.floor(Date.now() / 1000);
+			const elapsedTime = currentTime - $timerStartEpochStore;
+			const remainingTime = Math.max(0, $timerIntervalMinutesStore * 60 - elapsedTime);
+			return formatRemainingTime(remainingTime);
+		} else if ($roundInProgressStore === false) {
+			return `${$timerIntervalMinutesStore < 10 ? '0' : ''}${$timerIntervalMinutesStore}:00`;
+		}
+	}
 
+	function getTimePercentage() {
+		const secondsRemaining = formattedTimeToSeconds(time);
+		timePercentage = (secondsRemaining / ($timerIntervalMinutesStore * 60)) * 100;
+	}
+
+	function formatRemainingTime(remainingTime: number) {
+		if (remainingTime <= 0) return '00:00';
+		const minutes = Math.floor(remainingTime / 60);
+		const seconds = Math.floor(remainingTime % 60);
+
+		return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
+	}
+
+	function formattedTimeToSeconds(formattedTime: string) {
+		const split = formattedTime.split(':');
+		const minutes = parseInt(split[0]);
+		const seconds = parseInt(split[1]);
+		return minutes * 60 + seconds;
+	}
+
+	onMount(() => {
+		time = getRemainingTimeNewlyJoined() as string;
+		getTimePercentage();
+		timerInterval = setInterval(() => {
+			if ($roundInProgressStore) {
+				const newTime = getRemainingTime();
+				if (newTime) {
+					time = newTime;
+					getTimePercentage();
+					if (time === '00:00') {
+						setRoundInProgress(false);
+						setTimerStatus(true);
+						timePercentage = 100;
+					}
+				}
+			}
+		}, 500);
+	});
+
+	onDestroy(() => {
+		clearInterval(timerInterval);
+	});
+
+	watchStartEpoch();
 	watchTimerStatus();
+	watchPausedTimestamp();
+	watchRoundInProgress();
 </script>
 
 <div class="container">
 	<div class="timer-container flex justify-end">
 		<div
 			class="radial-progress text-primary font-bold text-4xl"
-			style="--value:{percentage}; --size:21rem; --thickness: 0.5rem;"
+			style="--value:{timePercentage}; --size:21rem; --thickness: 0.5rem;"
 		>
-			{displayMinutes}:{displaySeconds}
+			{time}
 		</div>
 	</div>
 
@@ -45,9 +107,30 @@
 			class="btn btn-primary join-item"
 			on:click={() => {
 				setTimerStatus(!$timerPausedStore);
-			}}>{$timerPausedStore ? 'Pause' : 'Start'}</button
+
+				if ($roundInProgressStore === true) {
+					if ($timerPausedStore === false) {
+						const currentEpoch = Date.now() / 1000;
+						const pausedDuration = currentEpoch - $timerPausedEpochStore;
+						const updatedStartEpoch = $timerStartEpochStore + pausedDuration;
+						setPausedTimestamp(0);
+						setStartEpoch(updatedStartEpoch);
+						setTimerStatus(false);
+					} else {
+						setPausedTimestamp(Date.now() / 1000);
+						setTimerStatus(true);
+					}
+				} else {
+					// set driver and navigator
+					// TODO ^
+					console.log('starting round');
+					setRoundInProgress(true);
+					setTimerStatus(false);
+					setStartEpoch(Date.now() / 1000);
+				}
+			}}>{$timerPausedStore ? 'Start' : 'Pause'}</button
 		>
-		<button class="btn join-item">Skip</button>
+		<button class="btn join-item">Next</button>
 		<button class="btn join-item">Restart</button>
 		<button class="btn join-item">Shuffle</button>
 	</div>

--- a/src/lib/components/Timer/Timer.svelte
+++ b/src/lib/components/Timer/Timer.svelte
@@ -78,6 +78,8 @@
 						timePercentage = 100;
 					}
 				}
+			} else {
+				time = `${$timerIntervalMinutesStore < 10 ? '0' : ''}${$timerIntervalMinutesStore}:00`;
 			}
 		}, 500);
 	});

--- a/src/lib/components/Timer/Timer.svelte
+++ b/src/lib/components/Timer/Timer.svelte
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <script lang="ts">
 	import {
 		watchTimerStatus,
@@ -41,25 +40,9 @@
 			return formatRemainingTime(remainingTime);
 		} else if ($roundInProgressStore === false) {
 			return `${$timerIntervalMinutesStore < 10 ? '0' : ''}${$timerIntervalMinutesStore}:00`;
-=======
-<script>
-	import { tweened } from 'svelte/motion';
-
-	let percentage = 80;
-	let elapsed = 0;
-	let startTime = 10 * 60;
-	let timer = tweened(startTime);
-	let timerIsRunning = false;
-
-	setInterval(() => {
-		if ($timer > 0 && timerIsRunning) {
-			$timer--;
-			elapsed++;
->>>>>>> main
 		}
 	}
 
-<<<<<<< HEAD
 	function getTimePercentage() {
 		const secondsRemaining = formattedTimeToSeconds(time);
 		timePercentage = (secondsRemaining / ($timerIntervalMinutesStore * 60)) * 100;
@@ -107,13 +90,6 @@
 	watchTimerStatus();
 	watchPausedTimestamp();
 	watchRoundInProgress();
-=======
-	$: percentage = 100 - (elapsed / startTime) * 100;
-	$: minutes = Math.floor($timer / 60);
-	$: seconds = Math.floor($timer - minutes * 60);
-	$: displayMinutes = minutes < 10 ? `0${minutes}` : minutes;
-	$: displaySeconds = seconds < 10 ? `0${seconds}` : seconds;
->>>>>>> main
 </script>
 
 <div class="container">
@@ -127,7 +103,6 @@
 	</div>
 
 	<div class="join mt-6 flex justify-end">
-<<<<<<< HEAD
 		<button
 			class="btn btn-primary join-item"
 			on:click={() => {
@@ -156,10 +131,6 @@
 			}}>{$timerPausedStore ? 'Start' : 'Pause'}</button
 		>
 		<button class="btn join-item">Next</button>
-=======
-		<button class="btn btn-primary join-item">Pause</button>
-		<button class="btn join-item">Skip</button>
->>>>>>> main
 		<button class="btn join-item">Restart</button>
 		<button class="btn join-item">Shuffle</button>
 	</div>

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -62,14 +62,11 @@ export function setTimerIntervalMinutes(minutes: number) {
 	set(ref(db, `/rooms/${roomId}/timerInterval`), minutes);
 }
 
-<<<<<<< HEAD
 export function setPausedTimestamp(epoch: number) {
 	timerPausedEpochStore.set(epoch);
 	set(ref(db, `/rooms/${roomId}/timer/pausedTimestamp`), epoch);
 }
 
-=======
->>>>>>> main
 export function watchTitle() {
 	const title = ref(db, `/rooms/${roomId}/title`);
 	onValue(title, (snapshot) => {
@@ -128,7 +125,6 @@ export function watchRoundInProgress() {
 		}
 	});
 }
-<<<<<<< HEAD
 
 export function setRoundInProgress(status: boolean) {
 	roundInProgressStore.set(status);
@@ -148,5 +144,3 @@ export function watchTimerStatus() {
 		}
 	});
 }
-=======
->>>>>>> main

--- a/src/lib/roomDefaults.ts
+++ b/src/lib/roomDefaults.ts
@@ -3,8 +3,26 @@ export const roomDefaults = {
 	participants: [] as string[],
 	timerIntervalMinutes: 10,
 	timerEndEpoch: undefined,
-	timerPaused: false,
+	timerLastEpoch: undefined,
+	timerPaused: true,
+	roundInProgress: false,
 	driver: undefined,
 	navigator: undefined,
+	timerStartEpoch: undefined,
 	epochLastActive: new Date().getUTCSeconds()
 };
+
+export interface Iroom {
+	title: string;
+	participants?: string[];
+	inProgress: boolean;
+	driver?: string;
+	navigator?: string;
+	//epochLastActive: number;
+	timerInterval: number;
+	timer: {
+		pausedTimestamp?: number;
+		startEpoch?: number;
+		paused: boolean;
+	};
+}

--- a/src/routes/[room]/+page.svelte
+++ b/src/routes/[room]/+page.svelte
@@ -3,17 +3,21 @@
 	import { initialiseApp } from '$lib/firebase.js';
 	import { Participants, Title, Timer, TimerEditor, ActiveParticipants } from '$lib/components';
 
-	initialiseApp(data.slug);
+	let firebaseData = initialiseApp(data.slug);
 </script>
 
 <div class="container mx-auto flex gap-12 mt-8">
-	<div class="left w-1/2"><Timer /></div>
-	<div class="right w-1/2 flex-col">
-		<Title />
-		<Participants />
-		<TimerEditor />
-		<div class="divider" />
-		<ActiveParticipants />
-		<div class="divider" />
-	</div>
+	{#await firebaseData}
+		<span class="loading loading-spinner loading-lg" />
+	{:then}
+		<div class="left w-1/2"><Timer /></div>
+		<div class="right w-1/2 flex-col">
+			<Title />
+			<Participants />
+			<TimerEditor />
+			<div class="divider" />
+			<ActiveParticipants />
+			<div class="divider" />
+		</div>
+	{/await}
 </div>


### PR DESCRIPTION
# Overview
A lot of changes in this PR...

Timer can correctly start/pause across web browsers, browsers joining at different times of the timer process (paused, running, finished) will show the correct time

The page now loads until all firestore data is sent to the client, this avoids weird bugs where it's trying to use the data before it's available

Timer displays the remaining time in mm:ss format with the radial percentage correctly decreasing down

Timer correctly resets to intervalTime (default 10:00) and radial percentage 100% when the timer is complete

## Next Steps
- Implement driver/navigator participants, space left in code to implement this inside the timer
- Disable timeInterval component from being edited while roundInProgress === true
- Add functionality to the other buttons (these shouldn't take as long)


